### PR TITLE
Added subghz_fill_random()

### DIFF
--- a/lora/subghz.c
+++ b/lora/subghz.c
@@ -795,6 +795,8 @@ void subghz_fill_random(uint8_t *randomStock, uint8_t len) {
     // Read four random bytes and save them in the buffer
     Radio.ReadBuffer(RANDOM_NUMBER_GENERATORBASEADDR, (uint8_t*)(randomStock + i), 4);
   }
+  
+  // Restore settings.
   Radio.Standby();
   Radio.Write(REG_ANA_LNA, regAnaLna);
   Radio.Write(REG_ANA_MIXER, regAnaMixer);

--- a/lora/subghz.c
+++ b/lora/subghz.c
@@ -782,22 +782,22 @@ void subghz_fill_random(uint8_t *randomStock, uint8_t len) {
   uint8_t regAnaLna = 0, regAnaMixer = 0;
 
   // Save original settings first, to restore them later...
-  Radio.Standby();
-  regAnaLna = Radio.Read(REG_ANA_LNA);
+  subghz_set_standby_mode(SUBGHZ_STDBY_HSE32);
+  subghz_read_reg(REG_ANA_LNA, &regAnaLna);
+  subghz_read_reg(REG_ANA_MIXER, &regAnaMixer);
   // Set radio in continuous reception
-  Radio.Write(REG_ANA_LNA, regAnaLna & ~(1 << 0));
-  regAnaMixer = Radio.Read(REG_ANA_MIXER);
-  Radio.Write(REG_ANA_MIXER, regAnaMixer & ~(1 << 7));
+  subghz_write_reg(REG_ANA_LNA, regAnaLna & ~(1 << 0));
+  subghz_write_reg(REG_ANA_MIXER, regAnaMixer & ~(1 << 7));
   // SX126xSetRx(0xFFFFFF); // Rx Continuous
-  Radio.Rx(0xFFFFFF);
+  subghz_set_rx_mode(0xFFFFFF);
 
   for (uint8_t i = 0; i < len; i += 4) {
     // Read four random bytes and save them in the buffer
-    Radio.ReadBuffer(RANDOM_NUMBER_GENERATORBASEADDR, (uint8_t*)(randomStock + i), 4);
+    subghz_read_regs(RANDOM_NUMBER_GENERATORBASEADDR, (uint8_t*)(randomStock + i), 4);
   }
   
   // Restore settings.
-  Radio.Standby();
-  Radio.Write(REG_ANA_LNA, regAnaLna);
-  Radio.Write(REG_ANA_MIXER, regAnaMixer);
+  subghz_set_standby_mode(SUBGHZ_STDBY_HSE32);
+  subghz_write_reg(REG_ANA_LNA, regAnaLna);
+  subghz_write_reg(REG_ANA_MIXER, regAnaMixer);
 }

--- a/lora/subghz.h
+++ b/lora/subghz.h
@@ -361,4 +361,7 @@ subghz_result_t subghz_set_packet_params(uint16_t preamble_length, subghz_det_le
                                          subghz_packet_crc_t crc_type, bool whitening);
 subghz_result_t subghz_set_lora_packet_params(uint16_t preamble_length, subghz_lora_packet_hdr_t header_type,
                                               uint8_t payload_length, bool crc_enabled, bool invert_iq);
+
+void fillRandom(uint8_t *randomStock, uint8_t len);
+
 #endif /* __INC_SUBGHZ_H */

--- a/lora/subghz.h
+++ b/lora/subghz.h
@@ -362,6 +362,6 @@ subghz_result_t subghz_set_packet_params(uint16_t preamble_length, subghz_det_le
 subghz_result_t subghz_set_lora_packet_params(uint16_t preamble_length, subghz_lora_packet_hdr_t header_type,
                                               uint8_t payload_length, bool crc_enabled, bool invert_iq);
 
-void fillRandom(uint8_t *randomStock, uint8_t len);
+void subghz_fill_random(uint8_t *randomStock, uint8_t len);
 
 #endif /* __INC_SUBGHZ_H */


### PR DESCRIPTION
This function enables the user to fill a buffer of `n` bytes (multiple of 4) with random bytes generated by the SX1262's TRNG engine. Since the SX1262 needs to be set up in a certain way before reading, and reset thereafter, the function does it all in sequence – and this is why it makes sense to fill a large-ish buffer in order to avoid multiples settings of the LoRa chip.

cf my [Sx1262LoRandom](https://github.com/Kongduino/Sx1262LoRandom) library for an example.